### PR TITLE
Add Move (Before/After) (Previous/Next) Sibling

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,6 +8,9 @@
   "command_indent":  { "message": "Indent Current Tab" },
   "command_outdent": { "message": "Outdent Current Tab" },
 
+  "command_moveBeforePreviousSibling":  { "message": "Move Current Tab Before Previous Sibling" },
+  "command_moveAfterNextSibling": { "message": "Move Current Tab After Next Sibling" },
+
   "context_moreTreeCommands_label": { "message": "Operate Tree" },
   "context_group_label":     { "message": "Create New &Group from tabs" },
   "context_group_command":   { "message": "Create New Group from tabs" },
@@ -19,6 +22,10 @@
   "context_indent_command":  { "message": "Indent" },
   "context_outdent_label":   { "message": "&Outdent" },
   "context_outdent_command": { "message": "Outdent" },
+  "context_moveBeforePreviousSibling_label":    { "message": "Move &before previous sibling" },
+  "context_moveBeforePreviousSibling_command":  { "message": "Move before previous sibling" },
+  "context_moveAfterNextSibling_label":   { "message": "Move &after next sibling" },
+  "context_moveAfterNextSibling_command": { "message": "Move after next sibling" },
 
 
   "config_title": { "message": "TST More Tree Commands Options" },

--- a/background/background.js
+++ b/background/background.js
@@ -285,7 +285,7 @@ async function getMultiselectedTabs(tab) {
 }
 
 async function getTreeItems(tabs) {
-  return browser.runtime.sendMessage(TST_ID, {
+  return tabs.length < 1 ? [] : browser.runtime.sendMessage(TST_ID, {
     type: 'get-tree',
     tabs: tabs.map(tab => tab.id || tab)
   });

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,12 @@
     },
     "outdent": {
       "description": "__MSG_command_outdent__"
+    },
+    "moveBeforePreviousSibling": {
+      "description": "__MSG_command_moveBeforePreviousSibling__"
+    },
+    "moveAfterNextSibling": {
+      "description": "__MSG_command_moveAfterNextSibling__"
     }
   },
   "options_ui": {

--- a/options/options.html
+++ b/options/options.html
@@ -28,6 +28,10 @@
                 __MSG_context_indent_command__</label></p>
       <p><label><input type="radio" name="contextMenuTopLevelCommand" value="outdent">
                 __MSG_context_outdent_command__</label></p>
+      <p><label><input type="radio" name="contextMenuTopLevelCommand" value="moveBeforePreviousSibling">
+                __MSG_context_moveBeforePreviousSibling_command__</label></p>
+      <p><label><input type="radio" name="contextMenuTopLevelCommand" value="moveAfterNextSibling">
+                __MSG_context_moveAfterNextSibling_command__</label></p>
     </fieldset>
 
     <p><label><input id="cleanupGroupTabsAfterFlattenTree"


### PR DESCRIPTION
These two commands allow moving tabs up and down while maintaining the same indentation level.

If this is the original state:

![Original](https://user-images.githubusercontent.com/7958605/104403214-e8490480-550c-11eb-934f-e7d80e0edd26.png)

Then running "Move Before Previous Sibling" on tab D results in:

![Move Before Previous Sibling](https://user-images.githubusercontent.com/7958605/104403231-f434c680-550c-11eb-9db8-bf6dc23677f4.png)

If we reset back to the original state and then run "Move After Next Sibling" on tab D instead, this results in:

![Move After Next Sibling](https://user-images.githubusercontent.com/7958605/104403299-1c242a00-550d-11eb-8f82-79379076d1bd.png)
